### PR TITLE
Moved id max length from 32 to 64 to match documentation

### DIFF
--- a/timeline_sync/models.py
+++ b/timeline_sync/models.py
@@ -25,7 +25,7 @@ class TimelinePin(db.Model):
     guid = db.Column(UUID(as_uuid=True), primary_key=True)
     app_uuid = db.Column(UUID(as_uuid=True), nullable=False)
     user_id = db.Column(db.Integer, nullable=False)
-    id = db.Column(db.String(32), nullable=False)
+    id = db.Column(db.String(64), nullable=False)
     time = db.Column(db.DateTime, nullable=False)
     duration = db.Column(db.Integer)
 


### PR DESCRIPTION
Updated token id max length based on documentation at https://developer.rebble.io/developer.pebble.com/guides/pebble-timeline/pin-structure/index.html